### PR TITLE
static_vector size_type

### DIFF
--- a/include/chobo/static_vector.hpp
+++ b/include/chobo/static_vector.hpp
@@ -186,16 +186,16 @@ public:
 
     static_vector() = default;
 
-    explicit static_vector(size_t count)
+    explicit static_vector(size_type count)
     {
         resize(count);
     }
 
-    static_vector(size_t count, const T& value)
+    static_vector(size_type count, const T& value)
     {
         _CHOBO_STATIC_VECTOR_OUT_OF_RANGE_IF(count > Capacity, );
 
-        for (size_t i = 0; i < count; ++i)
+        for (size_type i = 0; i < count; ++i)
         {
             push_back(value);
         }
@@ -219,8 +219,8 @@ public:
         }
     }
 
-    template <size_t CapacityB>
-    static_vector(const static_vector<T, CapacityB>& v)
+    template <size_t CapacityB, typename SizeTypeB>
+    static_vector(const static_vector<T, CapacityB, SizeTypeB>& v)
     {
         _CHOBO_STATIC_VECTOR_OUT_OF_RANGE_IF(v.size() > Capacity, );
 
@@ -392,17 +392,17 @@ public:
         return m_size == 0;
     }
 
-    size_t size() const noexcept
+    size_type size() const noexcept
     {
         return m_size;
     }
 
-    size_t max_size() const noexcept
+    size_type max_size() const noexcept
     {
         return Capacity;
     }
 
-    size_t capacity() const noexcept
+    size_type capacity() const noexcept
     {
         return Capacity;
     }
@@ -538,14 +538,14 @@ public:
             shorter = &v;
         }
 
-        for (size_t i = 0; i < shorter->size(); ++i)
+        for (size_type i = 0; i < shorter->size(); ++i)
         {
             std::swap(shorter->at(i), longer->at(i));
         }
 
         auto short_size = shorter->m_size;
 
-        for (size_t i = shorter->size(); i < longer->size(); ++i)
+        for (size_type i = shorter->size(); i < longer->size(); ++i)
         {
             shorter->emplace_back(std::move(longer->at(i)));
             longer->at(i).~T();
@@ -559,8 +559,8 @@ private:
     size_type m_size = 0;
 };
 
-template <typename T, size_t CapacityA, size_t CapacityB>
-bool operator==(const static_vector<T, CapacityA>& a, const static_vector<T, CapacityB>& b)
+template <typename T, size_t CapacityA, size_t CapacityB, typename SizeTypeA, typename SizeTypeB>
+bool operator==(const static_vector<T, CapacityA, SizeTypeA>& a, const static_vector<T, CapacityB, SizeTypeB>& b)
 {
     if (a.size() != b.size())
     {
@@ -576,8 +576,8 @@ bool operator==(const static_vector<T, CapacityA>& a, const static_vector<T, Cap
     return true;
 }
 
-template <typename T, size_t CapacityA, size_t CapacityB>
-bool operator!=(const static_vector<T, CapacityA>& a, const static_vector<T, CapacityB>& b)
+template <typename T, size_t CapacityA, size_t CapacityB, typename SizeTypeA, typename SizeTypeB>
+bool operator!=(const static_vector<T, CapacityA, SizeTypeA>& a, const static_vector<T, CapacityB, SizeTypeB>& b)
 {
     if (a.size() != b.size())
     {

--- a/include/chobo/static_vector.hpp
+++ b/include/chobo/static_vector.hpp
@@ -1,4 +1,4 @@
-// chobo-static-vector v1.03
+// chobo-static-vector v1.04
 //
 // std::vector-like class with a fixed capacity
 //
@@ -27,6 +27,7 @@
 //
 //                  VERSION HISTORY
 //
+//  1.04 (2020-04-06) size_type now optional.
 //  1.03 (2019-11-04) Proper noexcept specifiers on move ctor and assignment
 //  1.02 (2017-02-05) Added swap to make it a better drop-in replacement of std::vector
 //  1.01 (2016-09-27) Qualified operator new. Fixed self usurp on assignment
@@ -159,7 +160,7 @@
 namespace chobo
 {
 
-template<typename T, size_t Capacity>
+template<typename T, size_t Capacity, typename SizeType = size_t>
 struct static_vector
 {
     struct fake_allocator
@@ -171,7 +172,7 @@ struct static_vector
 
 public:
     using value_type = T;
-    using size_type = size_t;
+    using size_type = SizeType;
     using difference_type = ptrdiff_t;
     using reference = T&;
     using const_reference = const T&;
@@ -555,7 +556,7 @@ public:
 
 private:
     typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type m_data[Capacity];
-    size_t m_size = 0;
+    size_type m_size = 0;
 };
 
 template <typename T, size_t CapacityA, size_t CapacityB>
@@ -756,6 +757,12 @@ TEST_CASE("[static_vector] test")
     CHECK(svec2.size() == svec.size());
     CHECK(svec2.back() == "c");
     CHECK(svec.front() == "1");
+
+    // check size
+    {
+        static_vector<int, 4, int> svec;
+        CHECK(sizeof(svec) == sizeof(int)*5);
+    }
 }
 
 #endif

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,3 @@
 gen/
+.idea/
+cmake-build-*/


### PR DESCRIPTION
`static_vector` now have optional `size_type` as last argument. `size_t` by default.

```cpp
static_vector<std::uint16_t, 8, std::uint16_t> vec;
```

P.S. As further improvement, `size_type` can be deducted from Capacity.