### PR TITLE
small_vector::size() proper cast.

### DIFF
--- a/include/chobo/small_vector.hpp
+++ b/include/chobo/small_vector.hpp
@@ -509,7 +509,7 @@ public:
 
     size_t size() const noexcept
     {
-        return m_end - m_begin;
+        return static_cast<size_t>(m_end - m_begin);
     }
 
     size_t max_size() const noexcept

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,3 @@
 gen/
+.idea/
+cmake-build-*/


### PR DESCRIPTION
`static_cast` signed (ptrdiff) to unsigned (size_t) in `small_vector::size()`